### PR TITLE
Fix a bug:  After scrolling the images, visible pages won't remove the ones in recycled pages

### DIFF
--- a/Source/SSImageBrowser.swift
+++ b/Source/SSImageBrowser.swift
@@ -1095,7 +1095,7 @@ extension SSImageBrowser {
 				page.removeFromSuperview()
 			}
 		}
-		let _ = visiblePages.exclusiveOr(recycledPages)
+		visiblePages = visiblePages.subtract(recycledPages)
 
 		var pages = Set<SSZoomingScrollView>()
 		if recycledPages.count > 2 {


### PR DESCRIPTION
Please review my code