### PR TITLE
make target photo optional for avoid crash when quick swipe.

### DIFF
--- a/Source/SSZoomingScrollView.swift
+++ b/Source/SSZoomingScrollView.swift
@@ -80,14 +80,15 @@ public class SSZoomingScrollView: UIScrollView {
 		displayImage()
 	}
 
-	public func setProgress(progress: CGFloat, forPhoto aPhoto: SSPhoto!) {
+	public func setProgress(progress: CGFloat, forPhoto aPhoto: SSPhoto?) {
+        guard let targetPhoto = aPhoto else { return }
 		if let url = photo?.photoURL?.absoluteString {
-			if aPhoto.photoURL.absoluteString == url {
+			if targetPhoto.photoURL.absoluteString == url {
 				if progressView.progress < progress {
 					progressView.progress = progress
 				}
 			}
-		} else if aPhoto.asset.identifier == photo?.asset?.identifier {
+		} else if targetPhoto.asset.identifier == photo?.asset?.identifier {
 			if progressView.progress < progress {
 				progressView.progress = progress
 			}


### PR DESCRIPTION
 I have made aPhoto optional for 
public func setProgress(progress: CGFloat, forPhoto aPhoto: SSPhoto!) function to avoid quick swipe crash.